### PR TITLE
Update to work with tasty-0.7

### DIFF
--- a/Test/Tasty/Runners/AntXML.hs
+++ b/Test/Tasty/Runners/AntXML.hs
@@ -124,7 +124,10 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
       in do
         (Const summary, tests) <-
           flip State.runStateT 0 $ Functor.getCompose $ getTraversal $
-           Tasty.foldTestTree runTest runGroup (const id) options testTree
+           Tasty.foldTestTree
+             Tasty.trivialFold { Tasty.foldSingle = runTest, Tasty.foldGroup = runGroup }
+             options
+             testTree
 
         writeFile path $
           XML.showTopElement $

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -22,7 +22,7 @@ library
     reducers >= 3.10.1,
     stm >= 2.4.2,
     tagged >= 0.7,
-    tasty >= 0.5,
+    tasty >= 0.7,
     transformers >= 0.3.0.0,
     xml >= 1.3.13
   default-language: Haskell98


### PR DESCRIPTION
I took this chance to change the way `foldTestTree` takes an algebra. It's now easier to stay backwards-compatible, so hopefully I won't bother you with another breakage anytime soon.
