### PR TITLE
Update to tasty 0.8

### DIFF
--- a/Test/Tasty/Runners/AntXML.hs
+++ b/Test/Tasty/Runners/AntXML.hs
@@ -99,9 +99,12 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
               Tasty.Done result
                 | Tasty.resultSuccessful result -> pure mkSuccess
                 | otherwise -> case Tasty.resultException result of
-                    Just e -> pure $ (mkFailure (show e)) { summaryErrors = Sum 1 }
-                    _      -> pure $ (mkFailure (Tasty.resultDescription result))
-                                     { summaryFailures = Sum 1 }
+                    Just e  -> pure $ (mkFailure (show e)) { summaryErrors = Sum 1 }
+                    Nothing -> pure $
+                      if Tasty.resultTimedOut result
+                        then (mkFailure "TimeOut") { summaryErrors = Sum 1 }
+                        else (mkFailure (Tasty.resultDescription result))
+                             { summaryFailures = Sum 1 }
 
               -- Otherwise the test has either not been started or is currently
               -- executing


### PR DESCRIPTION
In tasty 0.8 the exceptions thrown by tests are considered test failures. I'm not familiar with Jenkins but the error would still be reported as the failure reason.

If you prefer, I could still report the test errors separately as in the previous version. We can consider a test time out another error in that case.
