### PR TITLE
Update to tasty-0.8 with no modifications in `tasty` itself

### DIFF
--- a/Test/Tasty/Runners/AntXML.hs
+++ b/Test/Tasty/Runners/AntXML.hs
@@ -98,13 +98,14 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
               -- If the test is done, generate XML for it
               Tasty.Done result
                 | Tasty.resultSuccessful result -> pure mkSuccess
-                | otherwise -> case Tasty.resultException result of
-                    Just e  -> pure $ (mkFailure (show e)) { summaryErrors = Sum 1 }
-                    Nothing -> pure $
-                      if Tasty.resultTimedOut result
-                        then (mkFailure "TimeOut") { summaryErrors = Sum 1 }
-                        else (mkFailure (Tasty.resultDescription result))
-                             { summaryFailures = Sum 1 }
+                | otherwise ->
+                    case resultException result of
+                      Just e  -> pure $ (mkFailure (show e)) { summaryErrors = Sum 1 }
+                      Nothing -> pure $
+                        if resultTimedOut result
+                          then (mkFailure "TimeOut") { summaryErrors = Sum 1 }
+                          else (mkFailure (Tasty.resultDescription result))
+                               { summaryFailures = Sum 1 }
 
               -- Otherwise the test has either not been started or is currently
               -- executing
@@ -146,3 +147,13 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
 
   appendChild parent child =
     parent { XML.elContent = XML.elContent parent ++ [ XML.Elem child ] }
+
+  resultException r =
+    case Tasty.resultOutcome r of
+         Tasty.Failure (Tasty.TestThrewException e) -> Just e
+         _ -> Nothing
+
+  resultTimedOut r =
+    case Tasty.resultOutcome r of
+         Tasty.Failure (Tasty.TestTimedOut _) -> True
+         _ -> False


### PR DESCRIPTION
I moved the rejected functions in feuerbach/tasty#58 within the package.

See #4 for the previous attempt.
