### PR TITLE
Output test results to a unique file in directory

### DIFF
--- a/Test/Tasty/Runners/AntXML.hs
+++ b/Test/Tasty/Runners/AntXML.hs
@@ -15,14 +15,15 @@ import Control.Arrow (first)
 import Control.Monad.IO.Class (liftIO)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
-import Data.Monoid (Monoid(..), Endo(..), Sum(..))
+import Data.Monoid ((<>), Monoid(..), Endo(..), Sum(..))
 import Data.Proxy (Proxy(..))
 import Data.Tagged (Tagged(..))
+import Data.Time.Clock (diffTimeToPicoseconds, utctDayTime, getCurrentTime)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Generics.Deriving.Monoid (memptydefault, mappenddefault)
-import System.Directory (createDirectoryIfMissing, canonicalizePath)
-import System.FilePath (takeDirectory)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, canonicalizePath)
+import System.FilePath (takeDirectory, (</>))
 
 import qualified Control.Concurrent.STM as STM
 import qualified Control.Monad.State as State
@@ -153,9 +154,9 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
              testTree
 
         return $ \elapsedTime -> do
-          createPathDirIfMissing path
-          writeFile path $
-            XML.showTopElement $
+          withOutputFile path $ \ file -> do
+            writeFile file $
+              XML.showTopElement $
               appEndo (xmlRenderer summary) $
                 XML.node
                   (XML.unqual "testsuites")
@@ -175,12 +176,23 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
   resultException r =
     case Tasty.resultOutcome r of
          Tasty.Failure (Tasty.TestThrewException e) -> Just e
-         _ -> Nothing
+         _                                          -> Nothing
 
   resultTimedOut r =
     case Tasty.resultOutcome r of
          Tasty.Failure (Tasty.TestTimedOut _) -> True
-         _ -> False
+         _                                    -> False
+
+  withOutputFile path act = do
+    isDir <- doesDirectoryExist path
+    (if isDir
+      then createUniqueFileNameIn path
+      else createPathDirIfMissing path) >>= act
+
+  createUniqueFileNameIn path = do
+    ns <- diffTimeToPicoseconds . utctDayTime <$> getCurrentTime
+    return $ path </> ("tasty-" <> show ns <> ".xml")
 
   createPathDirIfMissing path = fmap takeDirectory (canonicalizePath path)
                                 >>= createDirectoryIfMissing True
+                                >>  return path

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -27,6 +27,7 @@ library
     transformers >= 0.3.0.0,
     directory >= 1.2.3.0,
     filepath >= 1.0.0,
-    xml >= 1.3.13
+    xml >= 1.3.13,
+    time
   default-language: Haskell98
   ghc-options: -Wall -O2


### PR DESCRIPTION
When passed an existing directory as --xml parameter, test results
are output to a 'uniquely' named file (suffixed by current time in
ns) in this directory. This is useful when one wants to group test
results from different packages into a single location.