### PR TITLE
Bump tasty upper bound to 1.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -36,17 +36,21 @@ resolver: lts-7.14
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
 packages:
-- '.'
+  - "."
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  - tasty-1.3.1
+  - ansi-terminal-0.10.3
+  - ansi-wl-pprint-0.6.9
+  - optparse-applicative-0.15.1.0
+  - wcwidth-0.0.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []
-
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 #

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -23,7 +23,7 @@ library
     mtl >= 2.1.2,
     stm >= 2.4.2,
     tagged >= 0.7,
-    tasty >= 0.10 && < 1.3,
+    tasty >= 0.10 && < 1.4,
     transformers >= 0.3.0.0,
     directory >= 1.2.3.0,
     filepath >= 1.0.0,


### PR DESCRIPTION
I'm not sure if this is the right way to bump the upper bound for a dependency but I did not want to change the LTS version used in the stack.yaml. So I've just added the required changes to make it build with lts-7.14