### PR TITLE
Allows tasty-1.4

### DIFF
--- a/Test/Tasty/Runners/AntXML.hs
+++ b/Test/Tasty/Runners/AntXML.hs
@@ -136,7 +136,7 @@ antXMLRunner = Tasty.TestReporter optionDescription runner
 
           Const summary <$ State.modify (+ 1)
 
-        runGroup groupName children = Tasty.Traversal $ Functor.Compose $ do
+        runGroup _options groupName children = Tasty.Traversal $ Functor.Compose $ do
           Const soFar <- Reader.local (groupName :) $ Functor.getCompose $ Tasty.getTraversal children
 
           let grouped =

--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -23,7 +23,7 @@ library
     mtl >= 2.1.2,
     stm >= 2.4.2,
     tagged >= 0.7,
-    tasty >= 0.10 && < 1.4,
+    tasty >= 0.10 && < 1.5,
     transformers >= 0.3.0.0,
     directory >= 1.2.3.0,
     filepath >= 1.0.0,


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; I haven't tested this locally and this project doesn't have CI, but the `tasty-1.4` changelog implies that there shouldn't be any significant incompatibilities here.