### PR TITLE
Drop console formatting for failures and errors

### DIFF
--- a/tasty-ant-xml.cabal
+++ b/tasty-ant-xml.cabal
@@ -27,6 +27,9 @@ library
     transformers >= 0.3.0.0,
     directory >= 1.2.3.0,
     filepath >= 1.0.0,
-    xml >= 1.3.13
+    xml >= 1.3.13,
+    regex-base,
+    regex-posix,
+    array
   default-language: Haskell98
   ghc-options: -Wall -O2


### PR DESCRIPTION
I needed this change to deal with some exceptions which encode colour information in the text. It might be useful to others.